### PR TITLE
Add CSS after emailAuth

### DIFF
--- a/frontend/next/pages/email/index.tsx
+++ b/frontend/next/pages/email/index.tsx
@@ -70,12 +70,17 @@ export default function Auth(props: any) {
           <Button
             sx={{
               borderRadius: 16,
-              fontSize: '0.875rem',
+              fontSize: '16px',
               fontWeight: '700',
               top: 32,
               backgroundColor: '#333333',
               width: '242px',
               height: '48px',
+              '@media screen and (min-width:600px)': {
+                fontSize: '12px',
+                width: '168px',
+                height: '32px',
+              },
             }}
             variant='contained'
             color='primary'


### PR DESCRIPTION
## やったこと

* メール認証完了後画面のCSS追加（SP・PC共に）
* 不要なconsole.logの削除
* シングルクォーテーションに修正

## その他

* 未検討だったボタン下の誘導文章を変更していますが、他に良い案あれば修正可能です^^

## 画面キャプチャ

<img width="1078" alt="スクリーンショット 2022-10-10 19 35 48" src="https://user-images.githubusercontent.com/102156963/194847509-59b38f8d-5952-457b-9be3-0bc4d87053f4.png">
<img width="314" alt="スクリーンショット 2022-10-10 19 35 58" src="https://user-images.githubusercontent.com/102156963/194847514-87402ac9-eef5-424d-802a-50185fbce53f.png">
